### PR TITLE
Add more metrics that clusters-service needs

### DIFF
--- a/prometheus-telemeter-cache.yaml
+++ b/prometheus-telemeter-cache.yaml
@@ -257,6 +257,9 @@ objects:
       params:
         'match[]':
         - '{__name__="cluster_version"}'
+        - '{__name__=cluster_operator_up",name="openshift-apiserver"}'
+        - '{__name__="machine_cpu_cores"}'
+        - '{__name__="machine_memory_bytes"}'
       path: /federate
       port: https
       scheme: https


### PR DESCRIPTION
UNTESTED!  I don't know how to test this.

These are the metrics that clusters-service consumes currently.  More to come later.
https://gitlab.cee.redhat.com/service/uhc-clusters-service/blob/master/pkg/metrics/metrics.go  (private link)

cc @jfchevrette 