### PR TITLE
Add new infrastructure metrics

### DIFF
--- a/prometheus-telemeter-cache.yaml
+++ b/prometheus-telemeter-cache.yaml
@@ -255,11 +255,19 @@ objects:
       honorLabels: true
       interval: 60s
       params:
+        # https://github.com/openshift/telemeter/blob/master/jsonnet/telemeter/metrics.jsonnet
         'match[]':
         - '{__name__="cluster_version"}'
         - '{__name__="cluster_operator_up",name="openshift-apiserver"}'
+        - '{__name__="cluster:capacity_cpu_cores:sum"}'
+        - '{__name__="cluster:cpu_usage_cores:sum"}'
+        - '{__name__="openshift:cpu_usage_cores:sum"}'
         - '{__name__="machine_cpu_cores"}'
+        - '{__name__="cluster:capacity_memory_bytes:sum"}'
+        - '{__name__="cluster:memory_usage_bytes:sum"}'
+        - '{__name__="openshift:memory_usage_bytes:sum"}'
         - '{__name__="machine_memory_bytes"}'
+        - '{__name__="cluster:node_instance_type_count:sum"}'
       path: /federate
       port: https
       scheme: https


### PR DESCRIPTION
Added in https://github.com/openshift/telemeter/pull/143, data coming from https://github.com/openshift/cluster-monitoring-operator/pull/291.

We want to use these in cloud.openshift.com.  Not yet sure we need ALL of these, but I need to see them in the cache before I can figure out if anything can be dropped :eyes: (and need a period of overlap to transition :traffic_light:).

- memory_usage, cpu_usage metrics are new, definitely need them and have no other source.
- capacity_memory_bytes:sum, capacity_cpu_cores:sum might replace the fine grained machine_cpu_cores, machine_memory_bytes (?)
- the 2 `openshift:...` metrics giving usage only in `namespace=~"openshift-.+"` are new, not sure yet but we think we'll want this in UI.
- node_instance_type_count:sum is new, don't know if we'll want this but want to explore.